### PR TITLE
Bump to logstash 1.1.1

### DIFF
--- a/SPECS/logstash.spec
+++ b/SPECS/logstash.spec
@@ -6,7 +6,7 @@
 %define base_install_dir /opt/%{name}
 
 Name:           logstash
-Version:        1.1.0.1
+Version:        1.1.1
 Release:        1%{?dist}
 Summary:        Logstash is a tool for managing events and logs.
 


### PR DESCRIPTION
Logstash 1.1.1 is out. This trivial change allows to build the RPM for the latest&greatest version.

Thanks.
