### PR TITLE
Fix handling of default/empty log level

### DIFF
--- a/SOURCES/logstash.sysconfig
+++ b/SOURCES/logstash.sysconfig
@@ -2,3 +2,8 @@
 #LOGSTASH_PATH_CONF=/etc/logstash/conf.d
 #LOGSTASH_PATH_PLUGINS=/opt/logstash/plugins
 #LOGSTASH_JAVA_OPTS="-Djava.io.tmpdir=/opt/logstash/tmp"
+
+# Log level may be one of three values.
+#LOGSTASH_LOGLEVEL=warn
+#LOGSTASH_LOGLEVEL=info
+#LOGSTASH_LOGLEVEL=debug

--- a/SOURCES/logstash.wrapper
+++ b/SOURCES/logstash.wrapper
@@ -40,10 +40,10 @@ function run_service() {
   logfile=$5
 
   if [ "x$logfile" == "x" ]; then
-    exec "$JAVA" $JAVA_OPTS -jar $LOGSTASH_JAR $service -f "$config" -p "$pluginpath" "$verbose"
+    exec "$JAVA" $JAVA_OPTS -jar $LOGSTASH_JAR $service -f "$config" -p "$pluginpath" $verbose
     rs=$?
   else
-    exec "$JAVA" $JAVA_OPTS -jar $LOGSTASH_JAR $service -f "$config" -l "$logfile" -p "$pluginpath" "$verbose" 2>&1 >> $logfile &
+    exec "$JAVA" $JAVA_OPTS -jar $LOGSTASH_JAR $service -f "$config" -l "$logfile" -p "$pluginpath" $verbose 2>&1 >> $logfile &
     rs=$?
     [ $rs -eq 0 -a "x$pidfile" != "x" ] && printf '%d' $! > "$pidfile"
   fi
@@ -98,6 +98,8 @@ do
                             verbose="-vv"
                         elif [ "$2" == "info" ]; then
                             verbose="-v"
+                        else
+                            verbose=""
                         fi
                         shift 2
                         ;;

--- a/SPECS/logstash.spec
+++ b/SPECS/logstash.spec
@@ -7,7 +7,7 @@
 
 Name:           logstash
 Version:        1.1.0.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Logstash is a tool for managing events and logs.
 
 Group:          System Environment/Daemons
@@ -114,5 +114,9 @@ rm -rf $RPM_BUILD_ROOT
 
 
 %changelog
+* Mon Nov  5 2012 Dan Carley <dan.carley@gmail.com> - 1.1.0.1-2
+- Fix variable handling of default log level.
+- Document available log levels.
+
 * Fri May  4 2012 Maksim Horbul <max@gorbul.net> - 1.1.0-1
 - Initial package


### PR DESCRIPTION
Set $verbose to an empty string if no acceptable log level was passed. Then
unquote the resulting string in the exec command so that it can expand to
nothing. The contents are already sanitised so we shouldn't need to worry
about quoting any value.

Added examples of the three "known" logging levels that are parsed.

With the default configuration of `LOGSTASH_LOGLEVEL=warn` the wrapper
script was not setting the $verbose variable. The resulting command then
featured a pair of quotes with no contents inside: `""`

The logstash JAR rejected this with:

```
No such command ""
Available commands:
  -v
  -V
  --version
  agent
  web
  test
  irb
  pry
```
